### PR TITLE
Update use of SvelteKit and Vite

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,10 +12,10 @@
   },
   "homepage": "https://github.com/portabletext/svelte-portabletext#readme",
   "scripts": {
-    "dev": "svelte-kit dev",
-    "build:site": "svelte-kit build",
-    "package": "svelte-kit package",
-    "preview": "svelte-kit preview",
+    "dev": "vite dev",
+    "build:site": "vite build",
+    "package": "vite package",
+    "preview": "vite preview",
     "lint": "prettier --ignore-path .gitignore --check --plugin-search-dir=. . && eslint --ignore-path .gitignore .",
     "format": "prettier --ignore-path .gitignore --write --plugin-search-dir=. .",
     "prepublish": "npm run package && cd package",
@@ -25,8 +25,6 @@
   "devDependencies": {
     "@portabletext/types": "^1.0.3",
     "@sveltejs/adapter-auto": "^1.0.0-next.43",
-    "@sveltejs/kit": "^1.0.0-next.334",
-    "@sveltejs/vite-plugin-svelte": "^1.0.0-next.44",
     "@testing-library/svelte": "^3.1.1",
     "@typescript-eslint/eslint-plugin": "^5.25.0",
     "@typescript-eslint/parser": "^5.25.0",
@@ -35,6 +33,7 @@
     "eslint-config-prettier": "^8.5.0",
     "eslint-config-sanity": "^6.0.0",
     "eslint-plugin-svelte3": "^4.0.0",
+    "jsdom": "^20.0.0",
     "prettier": "^2.6.2",
     "prettier-plugin-svelte": "^2.7.0",
     "svelte": "^3.49.0",
@@ -48,6 +47,9 @@
   },
   "type": "module",
   "dependencies": {
-    "@portabletext/toolkit": "^1.0.5"
+    "@portabletext/toolkit": "^1.0.5",
+    "@sveltejs/kit": "^1.0.0-next.392",
+    "@sveltejs/vite-plugin-svelte": "^1.0.1",
+    "vite": "^3.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "eslint-plugin-svelte3": "^4.0.0",
     "prettier": "^2.6.2",
     "prettier-plugin-svelte": "^2.7.0",
-    "svelte": "^3.48.0",
+    "svelte": "^3.49.0",
     "svelte-preprocess": "^4.10.6",
     "svelte2tsx": "^0.5.10",
     "typescript": "^4.6.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@portabletext/svelte",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "author": "Sanity <hello@sanity.io>",
   "license": "MIT",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -42,9 +42,6 @@
     "typescript": "^4.6.4",
     "vitest": "latest"
   },
-  "peerDependencies": {
-    "svelte": "^3.47.0"
-  },
   "type": "module",
   "dependencies": {
     "@portabletext/toolkit": "^1.0.5",

--- a/src/app.html
+++ b/src/app.html
@@ -4,10 +4,10 @@
 		<meta charset="utf-8" />
 		<link rel="icon" href="/favicon.png" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
-		%svelte.head%
+		%sveltekit.head%
 		<link rel="stylesheet" href="https://vanillacss.com/vanilla.css">
 	</head>
 	<body>
-		<div id="svelte">%svelte.body%</div>
+		<div id="svelte">%sveltekit.body%</div>
 	</body>
 </html>

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,8 @@
+import { sveltekit } from '@sveltejs/kit/vite';
+
+/** @type {import('vite').UserConfig} */
+const config = {
+        plugins: [sveltekit()]
+};
+
+export default config;


### PR DESCRIPTION
- Upgrade to `svelte@^3.49.0` to patch a vulnerability.
- Handle the changes to SvelteKit in `1.0.0-next.359`, which included switching to the Vite CLI and requiring a vite.config.js file.
- Handle the changes to SvelteKit in `1.0.0-next.339`, which replaced placeholders like `%svelte.body%` with `%sveltekit.body%`, etc.