### PR TITLE
fix: correct default export

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "default": "./dist/bar.js",
+      "default": "./dist/index.js",
       "svelte": "./dist/index.js"
     }
   },


### PR DESCRIPTION
This PR fixes a broken export introduced in https://github.com/portabletext/svelte-portabletext/pull/32 as mentioned in https://github.com/portabletext/svelte-portabletext/issues/51 