### PR TITLE
fix: package.json conditional exports: default condition should be the last one

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "default": "./dist/index.js",
-      "svelte": "./dist/index.js"
+      "svelte": "./dist/index.js",
+      "default": "./dist/index.js"
     }
   },
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
During a dependency upgrade I was running into an error: `Module not found: Error: Default condition should be last one`.
After a bit of digging it seems that the source is this package and how the conditional exports are set up. The [documentation](https://nodejs.org/docs/latest-v20.x/api/packages.html#exports) says this about conditional exports (emhasis mine):

> `"default"`: the generic fallback that always matches. Can be a CommonJS or ES module file. **_This condition should always come last_**.

