### PR TITLE
fix: export InputValue from the package

### DIFF
--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -11,6 +11,10 @@ export {default as DefaultListItem} from './defaultComponents/DefaultListItem.sv
 export {default as DefaultMark} from './defaultComponents/DefaultMark.svelte'
 
 // Types
+export type { 
+  InputValue
+} from './ptTypes'
+
 export type {
   BlockComponentProps,
   CustomBlockComponentProps,


### PR DESCRIPTION
Importing InputValue directly would make it easier to write typesafe wrappers for `PortableText.svelte`.

An alternative solution to this is probably to use `@portabletext/types` but this approach is not covered in readme file. 