### PR TITLE
fix!: nest lists as deeply as their level says

### DIFF
--- a/.changeset/afraid-pugs-smile.md
+++ b/.changeset/afraid-pugs-smile.md
@@ -1,0 +1,58 @@
+---
+"@portabletext/svelte": major
+---
+
+Lists now nest as deeply as their `level` says they do
+
+#### When you will see a difference
+
+Only when your content has a list item that starts deeper than level 1, or that jumps more than one level at a time, such as going straight from level 1 to level 3. Lists that start at level 1 and change one level at a time render exactly as before.
+
+Portable Text stores list nesting as a flat `level` number on each block, and an editor lets an author produce both of those shapes. Previously the rendered nesting could be shallower than `level` said, and an item returning to a shallower level could start a new list instead of continuing the one it belonged to, which restarts the numbering of an `<ol>`.
+
+#### What changes
+
+Two list items, the first at level 3 and the second at level 1, used to render as two unrelated lists:
+
+```html
+<ul>
+  <li>Level 3</li>
+</ul>
+<ul>
+  <li>Level 1</li>
+</ul>
+```
+
+They now render as one list, three levels deep, with the second item as a sibling at the top:
+
+```html
+<ul>
+  <li>
+    <ul>
+      <li>
+        <ul>
+          <li>Level 3</li>
+        </ul>
+      </li>
+    </ul>
+  </li>
+  <li>Level 1</li>
+</ul>
+```
+
+The levels nobody authored have to be filled with something, and HTML can only put a list inside a list item, so they become empty list items. A browser draws a bullet or a number for each of them.
+
+#### What you may need to do
+
+Tests covering lists that start deep or skip levels will need updating.
+
+If the empty markers are visible somewhere you do not want them, the durable fix is the content itself, since a list skipping from level 1 to level 3 usually means an authoring mistake. To hide them in the meantime, target list items whose only child is a nested list:
+
+```css
+li:has(> ul:only-child),
+li:has(> ol:only-child) {
+  list-style: none;
+}
+```
+
+Note that in an `<ol>` this hides the number but the item still counts, so the numbering of the items after it is unchanged.

--- a/.changeset/olive-hoops-hear.md
+++ b/.changeset/olive-hoops-hear.md
@@ -1,0 +1,9 @@
+---
+"@portabletext/svelte": major
+---
+
+Node.js 22.12 or later is now required
+
+This package had no `engines` field before, so nothing was enforced. It now matches the rest of the Portable Text packages.
+
+Node.js 20 reached end of life in April 2026. If you build or server-render on Node.js 20, upgrade to 22.12 or later before taking this version.

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "test": "vitest"
   },
   "dependencies": {
-    "@portabletext/toolkit": "^2.0.18"
+    "@portabletext/toolkit": "^6.0.0"
   },
   "devDependencies": {
     "@changesets/changelog-github": "^0.5.1",
@@ -72,6 +72,9 @@
     "svelte": "^5.0.0"
   },
   "packageManager": "pnpm@10.15.0",
+  "engines": {
+    "node": ">=22.12"
+  },
   "publishConfig": {
     "access": "public"
   }

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@changesets/changelog-github": "^0.5.1",
     "@changesets/cli": "^2.29.6",
     "@portabletext/types": "^2.0.13",
-    "@sveltejs/adapter-auto": "^3.2.1",
+    "@sveltejs/adapter-auto": "^7.0.1",
     "@sveltejs/kit": "^2.8.0",
     "@sveltejs/package": "^2.3.1",
     "@sveltejs/vite-plugin-svelte": "^4.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@portabletext/toolkit':
-        specifier: ^2.0.18
-        version: 2.0.18
+        specifier: ^6.0.0
+        version: 6.0.0
     devDependencies:
       '@changesets/changelog-github':
         specifier: ^0.5.1
@@ -413,13 +413,17 @@ packages:
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
 
-  '@portabletext/toolkit@2.0.18':
-    resolution: {integrity: sha512-m3v2WwKQTNNk5BFZlUuPuCW0Zi6iDSpwrium4Ej5L2FHDXhFuwAyEMPXDrvwPvqjES/oJzcwmdKLMhYa44T9BQ==}
-    engines: {node: ^14.13.1 || >=16.0.0}
+  '@portabletext/toolkit@6.0.0':
+    resolution: {integrity: sha512-+qSqe0KnefuZfNLUhzQRTpbSKxslZof+3pNwxg0DC8dfZ1yLKyyBUw6iR7EpDL+SJlrnpiBfEcfmEuFitK1NSQ==}
+    engines: {node: '>=22.12'}
 
   '@portabletext/types@2.0.14':
     resolution: {integrity: sha512-LnAanK3vkn30gMqtGv5QoR0QT3fioOgqh1SBIiquAbtBcoETxhdvCfEMnv5CAuFiZMFLyRIgfpjWyIIVA2yOjQ==}
     engines: {node: ^14.13.1 || >=16.0.0 || >=18.0.0}
+
+  '@portabletext/types@4.0.2':
+    resolution: {integrity: sha512-djfIGU9n6DRrunlvj2nIDAp17URo/nA4jSXGvf+Gupx8NLLy9fmJBZ3GL8yhqn9lSVc+cKCharjOa3aOBnWbRw==}
+    engines: {node: '>=20.19 <22 || >=22.12'}
 
   '@rollup/rollup-android-arm-eabi@4.47.1':
     resolution: {integrity: sha512-lTahKRJip0knffA/GTNFJMrToD+CM+JJ+Qt5kjzBK/sFQ0EWqfKW3AYQSlZXN98tX0lx66083U9JYIMioMMK7g==}
@@ -2321,11 +2325,13 @@ snapshots:
 
   '@polka/url@1.0.0-next.29': {}
 
-  '@portabletext/toolkit@2.0.18':
+  '@portabletext/toolkit@6.0.0':
     dependencies:
-      '@portabletext/types': 2.0.14
+      '@portabletext/types': 4.0.2
 
   '@portabletext/types@2.0.14': {}
+
+  '@portabletext/types@4.0.2': {}
 
   '@rollup/rollup-android-arm-eabi@4.47.1':
     optional: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,8 +22,8 @@ importers:
         specifier: ^2.0.13
         version: 2.0.14
       '@sveltejs/adapter-auto':
-        specifier: ^3.2.1
-        version: 3.3.1(@sveltejs/kit@2.36.1(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.38.2)(vite@5.4.19))(svelte@5.38.2)(vite@5.4.19))
+        specifier: ^7.0.1
+        version: 7.0.1(@sveltejs/kit@2.36.1(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.38.2)(vite@5.4.19))(svelte@5.38.2)(vite@5.4.19))
       '@sveltejs/kit':
         specifier: ^2.8.0
         version: 2.36.1(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.38.2)(vite@5.4.19))(svelte@5.38.2)(vite@5.4.19)
@@ -533,8 +533,8 @@ packages:
     peerDependencies:
       acorn: ^8.9.0
 
-  '@sveltejs/adapter-auto@3.3.1':
-    resolution: {integrity: sha512-5Sc7WAxYdL6q9j/+D0jJKjGREGlfIevDyHSQ2eNETHcB1TKlQWHcAo8AS8H1QdjNvSXpvOwNjykDUHPEAyGgdQ==}
+  '@sveltejs/adapter-auto@7.0.1':
+    resolution: {integrity: sha512-dvuPm1E7M9NI/+canIQ6KKQDU2AkEefEZ2Dp7cY6uKoPq9Z/PhOXABe526UdW2mN986gjVkuSLkOYIBnS/M2LQ==}
     peerDependencies:
       '@sveltejs/kit': ^2.0.0
 
@@ -1198,9 +1198,6 @@ packages:
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
-
-  import-meta-resolve@4.1.0:
-    resolution: {integrity: sha512-I6fiaX09Xivtk+THaMfAwnA3MVA5Big1WHF1Dfx9hFuvNIWpXnorlkzhcQf6ehrqQiiZECRt1poOAkPmer3ruw==}
 
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
@@ -2399,10 +2396,9 @@ snapshots:
     dependencies:
       acorn: 8.15.0
 
-  '@sveltejs/adapter-auto@3.3.1(@sveltejs/kit@2.36.1(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.38.2)(vite@5.4.19))(svelte@5.38.2)(vite@5.4.19))':
+  '@sveltejs/adapter-auto@7.0.1(@sveltejs/kit@2.36.1(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.38.2)(vite@5.4.19))(svelte@5.38.2)(vite@5.4.19))':
     dependencies:
       '@sveltejs/kit': 2.36.1(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.38.2)(vite@5.4.19))(svelte@5.38.2)(vite@5.4.19)
-      import-meta-resolve: 4.1.0
 
   '@sveltejs/kit@2.36.1(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.38.2)(vite@5.4.19))(svelte@5.38.2)(vite@5.4.19)':
     dependencies:
@@ -3138,8 +3134,6 @@ snapshots:
     dependencies:
       parent-module: 1.0.1
       resolve-from: 4.0.0
-
-  import-meta-resolve@4.1.0: {}
 
   imurmurhash@0.1.4: {}
 

--- a/tests/render-tests/016-deep-weird-lists.svelte
+++ b/tests/render-tests/016-deep-weird-lists.svelte
@@ -40,8 +40,13 @@
   </li>
   <li>
     All the way back
+    <!-- Level 1 -> 3 skips a level, so an empty list item holds the generated level 2 list -->
     <ul>
-      <li>Skip a step</li>
+      <li>
+        <ul>
+          <li>Skip a step</li>
+        </ul>
+      </li>
     </ul>
   </li>
 </ul>

--- a/tests/render-tests/065-skipped-list-levels.svelte
+++ b/tests/render-tests/065-skipped-list-levels.svelte
@@ -1,0 +1,29 @@
+<ol>
+  <li>
+    <ol>
+      <li>
+        <ol>
+          <li>Level 3, item 1</li>
+        </ol>
+      </li>
+    </ol>
+  </li>
+  <li>Level 1, item 2</li>
+</ol>
+<ul>
+  <li>
+    Level 1 bullet
+    <ul>
+      <li>
+        <ul>
+          <li>
+            <ul>
+              <li>Level 4 bullet</li>
+            </ul>
+          </li>
+        </ul>
+      </li>
+    </ul>
+  </li>
+  <li>Level 1 bullet again</li>
+</ul>

--- a/tests/render-tests/065-skipped-list-levels.ts
+++ b/tests/render-tests/065-skipped-list-levels.ts
@@ -1,0 +1,83 @@
+import Rendered from './065-skipped-list-levels.svelte'
+
+export default {
+  name: '065-skipped-list-levels',
+  rendered: Rendered,
+  value: [
+    {
+      listItem: 'number',
+      style: 'normal',
+      level: 3,
+      _type: 'block',
+      _key: 'level-3-item-1',
+      markDefs: [],
+      children: [
+        {
+          _type: 'span',
+          text: 'Level 3, item 1',
+          marks: []
+        }
+      ]
+    },
+    {
+      listItem: 'number',
+      style: 'normal',
+      level: 1,
+      _type: 'block',
+      _key: 'level-1-item-2',
+      markDefs: [],
+      children: [
+        {
+          _type: 'span',
+          text: 'Level 1, item 2',
+          marks: []
+        }
+      ]
+    },
+    {
+      listItem: 'bullet',
+      style: 'normal',
+      level: 1,
+      _type: 'block',
+      _key: 'level-1-bullet',
+      markDefs: [],
+      children: [
+        {
+          _type: 'span',
+          text: 'Level 1 bullet',
+          marks: []
+        }
+      ]
+    },
+    {
+      listItem: 'bullet',
+      style: 'normal',
+      level: 4,
+      _type: 'block',
+      _key: 'level-4-bullet',
+      markDefs: [],
+      children: [
+        {
+          _type: 'span',
+          text: 'Level 4 bullet',
+          marks: []
+        }
+      ]
+    },
+    {
+      listItem: 'bullet',
+      style: 'normal',
+      level: 1,
+      _type: 'block',
+      _key: 'level-1-bullet-again',
+      markDefs: [],
+      children: [
+        {
+          _type: 'span',
+          text: 'Level 1 bullet again',
+          marks: []
+        }
+      ]
+    }
+  ]
+}

--- a/tests/render-tests/index.ts
+++ b/tests/render-tests/index.ts
@@ -25,6 +25,7 @@ import test026 from './026-inline-block-with-text'
 import test027 from './027-styled-list-items'
 import test052 from './052-custom-marks'
 import test053 from './053-override-default-marks'
+import test065 from './065-skipped-list-levels'
 import test061 from './061-missing-mark-serializer'
 
 interface RenderTestFile {
@@ -60,5 +61,6 @@ export default [
   test027,
   test052,
   test053,
-  test061
+  test061,
+  test065
 ] as RenderTestFile[]


### PR DESCRIPTION
Picks up the `nestLists()` fix from `@portabletext/toolkit@6.0.0`, which is a four major jump from the `^2.0.18` this was pinned to.

## What was wrong

A list item can start at a level deeper than 1, and can skip any number of levels at a time. Neither was accounted for, so a level 3 item could be rendered only one list deep, and items that later returned to a shallower level could start a new list rather than continuing the one they belonged to.

Rendering `[level 3, level 1]` goes from two sibling lists to:

```html
<ul>
  <li>
    <ul>
      <li>
        <ul>
          <li>Level 3</li>
        </ul>
      </li>
    </ul>
  </li>
  <li>Level 1</li>
</ul>
```

That is the shape the reporter asked for in portabletext/toolkit#100.

## Changes

- `@portabletext/toolkit` bumped from `^2.0.18` to `^6.0.0`
- New fixture `065-skipped-list-levels`, covering a list that starts at level 3 and a level 1 to level 4 jump and back, neither of which was covered before
- `016-deep-weird-lists` expectation updated for its "Skip a step" case, which goes from level 1 straight to level 3
- `engines.node` declared for the first time, at `>=22.12`, matching the rest of the Portable Text packages

## Note on the four major jump

Toolkit v3 dropped Sanity Studio v2 support, v4 raised the Node floor and removed CJS exports, v5 moved to `@portabletext/types` v4, and v6 is this list fix. **Only the list change affected anything here.** Of the 25 existing tests, exactly one failed after the bump, and it was `016-deep-weird-lists` on the "Skip a step" case. This package was already ESM only, so the v4 CJS removal was a non-event.

## Note on the empty list item

A generated level renders as an `<li>` with no text, so a browser draws a bullet or a number for it. That is inherent to HTML, which cannot nest a list directly inside a list, and it matches the expected output in the original issue.

## Verification

26 tests pass, `pnpm lint` clean, and `svelte-package` runs `publint` which reports "All good!".

Refs portabletext/toolkit#100
